### PR TITLE
[GH-15] Agent skill expansions: SME agents per security domain vs. single adaptive security agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "miniature-guacamole",
-  "version": "1.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miniature-guacamole",
-      "version": "1.1.0",
+      "version": "3.0.0",
       "license": "MIT",
+      "bin": {
+        "mg-studio": "dist/studio/cli.js"
+      },
       "devDependencies": {
         "@playwright/test": "^1.40.0",
         "@types/js-yaml": "^4.0.9",

--- a/src/framework/agents/security-engineer/agent.md
+++ b/src/framework/agents/security-engineer/agent.md
@@ -20,6 +20,17 @@ You perform security reviews and vulnerability assessments.
 5. **Memory-first** - Read security policies, write findings
 6. **Visual standards** - Use ASCII progress patterns from shared output format
 
+## Domain Selection
+
+Before starting a review, infer the relevant security domain from the task context, codebase, and request details. Read the corresponding domain reference file from `domains/` to load specialized checklists, threat models, and review areas for that domain.
+
+- **web** — `domains/web.md` — Web applications, HTTP APIs, browser-facing code, authentication flows, OWASP Top 10
+- **systems** — `domains/systems.md` — OS hardening, daemon/service security, process isolation, file permissions, privilege management
+- **cloud** — `domains/cloud.md` — Cloud infrastructure, IAM, container security, CI/CD pipelines, secrets management, supply chain
+- **crypto** — `domains/crypto.md` — Encryption, hashing, key management, TLS configuration, algorithm selection, digital signatures
+
+If the task spans multiple domains, read all applicable reference files. When the domain is ambiguous, default to reading all four files to ensure comprehensive coverage. The domain reference files provide actionable checklists — apply them alongside the general review areas below.
+
 ## Memory Protocol
 
 ```yaml
@@ -34,6 +45,7 @@ read:
 write: .claude/memory/security-findings.json
   workstream_id: <id>
   status: secure | vulnerable | needs_review
+  domains_reviewed: [web, systems, cloud, crypto]  # which domains were assessed
   findings:
     - severity: critical | high | medium | low
       category: <OWASP category>

--- a/src/framework/agents/security-engineer/domains/cloud.md
+++ b/src/framework/agents/security-engineer/domains/cloud.md
@@ -1,0 +1,38 @@
+# Cloud Security
+
+Domain reference for cloud infrastructure, container, and deployment security reviews. Load this file when the review targets cloud-hosted services, container orchestration, CI/CD pipelines, or infrastructure-as-code.
+
+## Review Areas
+
+1. **Identity and Access Management (IAM)** — Verify IAM policies follow least privilege (no wildcard actions or resources), check for overly permissive service account roles, review cross-account trust relationships, confirm MFA enforcement, and validate temporary credential usage over long-lived keys.
+2. **Secrets Management** — Verify secrets stored in dedicated vaults (AWS Secrets Manager, HashiCorp Vault), check secrets are not committed to version control, review secret rotation policies, confirm runtime injection over baked-in configs, and validate encryption at rest and in transit.
+3. **Network Policy and Isolation** — Review VPC/network segmentation and security groups, check for overly permissive ingress/egress rules (0.0.0.0/0), verify private subnets for internal services, confirm TLS termination, and review firewall rules and network ACLs.
+4. **Container and Orchestration Security** — Verify container images use minimal base images (distroless, alpine), check for root containers, review Kubernetes RBAC and pod security standards, confirm image scanning in CI pipeline, and validate resource limits.
+5. **Supply Chain and Dependency Security** — Verify dependency lock files are committed, check for known vulnerabilities (npm audit, Snyk, Trivy), review CI/CD pipeline permissions and artifact signing, confirm base images pinned to digest, and validate SBOM generation.
+6. **Data and Storage Security** — Verify storage buckets are not publicly accessible, check encryption at rest for databases and object stores, review backup encryption, and confirm logging and audit trails for data access.
+
+## Threat Model
+
+1. **IAM policy misconfiguration** — Overly broad IAM policies grant attackers lateral movement or data exfiltration after initial compromise. Mitigate with policy linting, automated least-privilege analysis, and regular access reviews.
+2. **Exposed secrets** — Credentials leaked in source code, CI logs, or container images enable unauthorized access. Mitigate with secret scanning in CI, vault-based secret injection, and automated rotation.
+3. **Network exposure** — Misconfigured security groups or public endpoints expose internal services to the internet. Mitigate with infrastructure-as-code reviews, network policy enforcement, and regular port scanning.
+4. **Container escape** — Attacker breaks out of a container to access the host or other containers. Mitigate with non-root containers, read-only file systems, seccomp profiles, and pod security standards.
+5. **Supply chain compromise** — Attacker injects malicious code via compromised dependencies, base images, or CI plugins. Mitigate with dependency pinning, image digest verification, and pipeline isolation.
+6. **Data exfiltration** — Attacker accesses cloud storage or databases via misconfigured permissions. Mitigate with bucket policies, VPC endpoints, and data access logging.
+
+## Checklist
+
+- [ ] IAM policies use explicit allow with specific actions and resources (no wildcards)
+- [ ] Service accounts have dedicated roles scoped to their function
+- [ ] All secrets stored in vault/secrets manager (not in env files, repos, or images)
+- [ ] Secret rotation automated with maximum 90-day lifetime
+- [ ] Security groups restrict ingress to required ports and known CIDR ranges
+- [ ] Internal services deployed in private subnets with no public IP
+- [ ] Container images scanned for CVEs before deployment
+- [ ] Containers run as non-root with read-only root filesystem
+- [ ] Kubernetes pods have resource limits, network policies, and security contexts
+- [ ] Dependencies pinned with lock files and audited for known vulnerabilities
+- [ ] CI/CD pipeline artifacts are signed and verified before deployment
+- [ ] Storage buckets have explicit deny for public access
+- [ ] Audit logging enabled for all cloud APIs and data access
+- [ ] Infrastructure changes deployed via IaC with peer review (no manual console changes)

--- a/src/framework/agents/security-engineer/domains/crypto.md
+++ b/src/framework/agents/security-engineer/domains/crypto.md
@@ -1,0 +1,36 @@
+# Cryptography
+
+Domain reference for cryptographic implementation and key management security reviews. Load this file when the review targets encryption, hashing, digital signatures, key management, or TLS/certificate handling.
+
+## Review Areas
+
+1. **Key Management and Rotation** — Verify encryption keys are stored in HSM or key management services, check key rotation policies with defined maximum lifetime, review key derivation functions (KDF) for appropriate parameters, confirm key material is never logged or exposed, and validate separate keys for different purposes.
+2. **Transport Layer Security (TLS)** — Verify TLS 1.2+ enforcement (TLS 1.0/1.1 disabled), check cipher suite configuration (prefer AEAD ciphers like AES-GCM, ChaCha20-Poly1305), review certificate validation and chain verification, confirm certificate pinning where appropriate, and validate HSTS deployment.
+3. **Algorithm and Cipher Selection** — Verify modern algorithms are used (AES-256-GCM, Ed25519, X25519), check for deprecated or broken algorithms (MD5, SHA-1, DES, RC4, ECB mode), review random number generation (CSPRNG), confirm appropriate key sizes, and validate authenticated encryption modes.
+4. **Hashing and Password Storage** — Verify password hashing uses memory-hard functions (argon2id, bcrypt, scrypt), check hash function selection for integrity (SHA-256/SHA-3), review HMAC usage for message authentication, confirm unique salts per password, and validate constant-time hash digest comparison.
+5. **Digital Signatures and Verification** — Verify signature algorithms (Ed25519, ECDSA P-256, RSA-PSS), check signature verification on all received signed data, review code signing and artifact verification in CI/CD, and confirm nonce/timestamp inclusion to prevent replay attacks.
+
+## Threat Model
+
+1. **Weak algorithm usage** — Application uses deprecated algorithms (MD5, SHA-1, DES, RC4) that are vulnerable to collision or brute-force attacks. Mitigate by maintaining an approved algorithm list and scanning for deprecated usage.
+2. **Key exposure** — Encryption keys leaked via logs, error messages, or insecure storage enable decryption of protected data. Mitigate with HSM/KMS storage, memory protection, and key access auditing.
+3. **Improper randomness** — Use of predictable random sources (Math.random, unseeded PRNGs) for cryptographic operations enables prediction attacks. Mitigate by mandating CSPRNG (crypto.randomBytes, /dev/urandom) for all security-sensitive randomness.
+4. **Downgrade attacks** — Attacker forces negotiation of weaker TLS versions or cipher suites. Mitigate with strict TLS configuration, disabling legacy protocols, and testing with tools like testssl.sh.
+5. **Padding oracle attacks** — Attacker exploits error messages from CBC-mode decryption to recover plaintext. Mitigate by using AEAD modes (GCM) and constant-time error handling.
+6. **Replay attacks** — Attacker resubmits valid signed messages to perform duplicate operations. Mitigate with nonces, timestamps, and sequence numbers in signed payloads.
+
+## Checklist
+
+- [ ] All symmetric encryption uses AES-256-GCM or ChaCha20-Poly1305 (AEAD)
+- [ ] No use of ECB mode, bare CBC without HMAC, or stream ciphers without authentication
+- [ ] Password hashing uses argon2id, bcrypt (cost >= 10), or scrypt
+- [ ] All hash comparisons use constant-time functions (crypto.timingSafeEqual)
+- [ ] Random values for tokens, nonces, and keys generated via CSPRNG
+- [ ] TLS 1.2+ enforced; TLS 1.0 and 1.1 disabled
+- [ ] Cipher suites limited to AEAD algorithms with forward secrecy (ECDHE)
+- [ ] RSA keys >= 2048 bits; ECC keys >= 256 bits; Ed25519 preferred for signatures
+- [ ] Key rotation policy defined with maximum key lifetime
+- [ ] Encryption keys stored in KMS/HSM, not in source code or config files
+- [ ] No deprecated algorithms in use (MD5, SHA-1, DES, 3DES, RC4, Blowfish)
+- [ ] Digital signatures verified before trusting any signed payload
+- [ ] Certificate validation enabled (no skip-verify flags in production)

--- a/src/framework/agents/security-engineer/domains/systems.md
+++ b/src/framework/agents/security-engineer/domains/systems.md
@@ -1,0 +1,36 @@
+# Systems Security
+
+Domain reference for operating system, infrastructure, and daemon security reviews. Load this file when the review targets system-level code, background services, CLI tools, file system operations, or process management.
+
+## Review Areas
+
+1. **Process Isolation and Sandboxing** — Verify processes run with minimum required privileges (not root/admin), check for proper use of sandboxing mechanisms (seccomp, AppArmor, macOS sandbox), review subprocess spawning for shell injection, and validate process isolation between workloads.
+2. **File System and Permissions** — Verify sensitive files have restrictive permissions (600/700, not world-readable), check for path traversal vulnerabilities, review temporary file creation for TOCTOU race conditions, and validate symlink handling.
+3. **Daemon and Service Security** — Review daemon lifecycle management, check that services drop privileges after binding to privileged ports, verify PID/lock file handling, and review launchd/systemd unit files for security directives.
+4. **Privilege Escalation Prevention** — Check for SUID/SGID binaries and justify each one, review sudo configurations for least privilege, verify setuid/setgid error handling, and confirm no capability leaks through environment variables or file descriptors.
+5. **System Hardening** — Verify unnecessary services are disabled, check kernel parameters and sysctl settings, review network listener exposure for unintended open ports, and validate backup and recovery procedures.
+
+## Threat Model
+
+1. **Privilege escalation** — Attacker exploits misconfigured SUID binaries, weak sudo rules, or capability leaks to gain root access. Mitigate with least privilege enforcement, capability dropping, and regular SUID audits.
+2. **Subprocess injection** — Attacker controls arguments or environment variables passed to child processes, achieving code execution. Mitigate by using exec-style calls (no shell), validating all inputs, and sanitizing environment.
+3. **File system race conditions** — Attacker exploits TOCTOU gaps between checking and using files to swap in malicious content. Mitigate with atomic file operations, O_NOFOLLOW, and secure temporary directory creation.
+4. **Daemon compromise** — Attacker exploits a long-running service to gain persistent access. Mitigate with process isolation, automatic restart policies, and minimal attack surface.
+5. **Supply chain attacks** — Attacker compromises build tools, dependencies, or update mechanisms to inject malicious code. Mitigate with checksum verification, signed packages, and reproducible builds.
+6. **Information disclosure** — Attacker reads sensitive data from logs, core dumps, or environment variables. Mitigate with secret redaction, restricted file permissions, and disabled core dumps for sensitive processes.
+
+## Checklist
+
+- [ ] All services and daemons run as dedicated non-root users
+- [ ] Subprocess calls use exec-style invocation (no shell interpolation)
+- [ ] Sensitive files (keys, configs, secrets) are chmod 600 or 640
+- [ ] Temporary files created with mkstemp/mkdtemp in restricted directories
+- [ ] launchd/systemd units include hardening directives (NoNewPrivileges, ProtectHome)
+- [ ] SUID/SGID binaries are inventoried and justified
+- [ ] Environment variables sanitized before passing to child processes
+- [ ] PID files and lock files use atomic creation with proper cleanup
+- [ ] Core dumps disabled or restricted for processes handling secrets
+- [ ] Log files rotated and permissions set to 640 or stricter
+- [ ] File descriptor inheritance explicitly controlled (CLOEXEC)
+- [ ] Signal handlers are async-signal-safe and cannot be abused
+- [ ] Binary integrity verified via code signing or checksums

--- a/src/framework/agents/security-engineer/domains/web.md
+++ b/src/framework/agents/security-engineer/domains/web.md
@@ -1,0 +1,52 @@
+# Web Security
+
+Domain reference for web application security reviews. Load this file when the review targets HTTP services, browser-facing applications, APIs, or any code that handles web requests and responses.
+
+## Review Areas
+
+1. **Authentication and Session Management** — Verify authentication mechanisms (OAuth/OIDC, JWT, session cookies), session token generation with CSPRNG, session expiration and invalidation on logout, password storage with bcrypt/scrypt/argon2, and multi-factor authentication (MFA) implementation.
+2. **Input Validation and Injection Prevention** — Check all user inputs are validated and sanitized server-side, review parameterized queries for SQL injection (SQLi) prevention, verify output encoding to prevent Cross-Site Scripting (XSS), check for command injection in shell/exec calls, and validate file upload restrictions.
+3. **Authorization and Access Control** — Verify role-based access control (RBAC) enforcement on every endpoint, check for insecure direct object references (IDOR), review API authorization scopes and resource ownership, confirm admin function protection, and validate CORS configuration.
+4. **Transport and Data Protection** — Confirm TLS enforcement with HSTS headers, review Content Security Policy (CSP) headers, check cookie attributes (Secure, HttpOnly, SameSite), verify sensitive data is not leaked in error messages, and review API key management.
+5. **CSRF and Request Integrity** — Verify Cross-Site Request Forgery (CSRF) tokens on state-changing endpoints, check anti-CSRF mechanisms for SPA architectures, and review CORS preflight configuration for cross-origin requests.
+
+## Threat Model
+
+1. **Injection attacks** — Attacker sends crafted input (SQL, NoSQL, OS commands, LDAP) to execute unintended operations. Mitigate with parameterized queries, input validation, and least-privilege database accounts.
+2. **Cross-Site Scripting (XSS)** — Attacker injects malicious scripts into pages viewed by other users, stealing sessions or credentials. Mitigate with context-aware output encoding and strict CSP.
+3. **Broken authentication** — Attacker exploits weak credential storage, session fixation, or missing brute-force protection to impersonate users. Mitigate with secure password hashing, rate limiting, and MFA.
+4. **CSRF and request forgery** — Attacker tricks authenticated users into performing unintended actions. Mitigate with anti-CSRF tokens and SameSite cookie attributes.
+5. **Server-Side Request Forgery (SSRF)** — Attacker manipulates server to make requests to internal resources. Mitigate with URL allowlists and blocking internal network ranges.
+6. **Insecure deserialization** — Attacker sends crafted serialized objects to achieve remote code execution or privilege escalation. Mitigate by avoiding native deserialization of untrusted data.
+
+## Checklist
+
+- [ ] All endpoints require authentication unless explicitly public
+- [ ] Passwords hashed with bcrypt/scrypt/argon2 (cost factor >= 10)
+- [ ] SQL queries use parameterized statements (no string concatenation)
+- [ ] All user-rendered output is context-encoded (HTML, JS, URL, CSS)
+- [ ] CSRF protection on every state-changing endpoint
+- [ ] CORS Access-Control-Allow-Origin does not use wildcard for credentialed requests
+- [ ] Content-Security-Policy header deployed and restricts inline scripts
+- [ ] Strict-Transport-Security header with max-age >= 31536000
+- [ ] Session cookies set with Secure, HttpOnly, and SameSite attributes
+- [ ] Rate limiting on login, registration, and password reset endpoints
+- [ ] File uploads validated by content type, not just extension
+- [ ] Error responses do not leak stack traces, SQL errors, or internal paths
+- [ ] No hardcoded API keys, tokens, or secrets in source code
+- [ ] OWASP Top 10 (2021) coverage verified for each applicable category
+
+## OWASP Top 10 (2021) Mapping
+
+| Category | Key Checks |
+|----------|-----------|
+| A01 Broken Access Control | RBAC enforcement, IDOR, CORS, directory traversal |
+| A02 Cryptographic Failures | TLS, password hashing, secret exposure |
+| A03 Injection | SQLi, XSS, command injection, LDAP injection |
+| A04 Insecure Design | Threat modeling, abuse case coverage |
+| A05 Security Misconfiguration | Default credentials, verbose errors, unnecessary features |
+| A06 Vulnerable Components | Dependency audit, known CVEs |
+| A07 Identity & Auth Failures | MFA, session management, credential stuffing |
+| A08 Software & Data Integrity | CI/CD pipeline security, unsigned updates |
+| A09 Logging & Monitoring | Security event logging, alerting |
+| A10 SSRF | URL validation, internal network protection |

--- a/src/framework/skills/mg-security-review/SKILL.md
+++ b/src/framework/skills/mg-security-review/SKILL.md
@@ -47,6 +47,7 @@ write: .claude/memory/agent-security-review-decisions.json
   workstream_id: <id>
   phase: scanning | analysis | reporting
   audit_status: secure | vulnerable | needs_review
+  domains_reviewed: [web, systems, cloud, crypto]  # which security domains were assessed
   findings:
     - severity: CRITICAL | HIGH | MEDIUM | LOW
       category: <OWASP category or type>
@@ -58,34 +59,59 @@ write: .claude/memory/agent-security-review-decisions.json
   next_owner: dev | engineering-manager
 ```
 
+## Domain Inference
+
+Before spawning the security-engineer, infer the relevant security domain(s) from project signals. Scan the codebase and task context for these heuristics to auto-detect the applicable domain without requiring user intervention.
+
+| Domain | Signal Keywords & File Patterns | Examples |
+|--------|---------------------------------|----------|
+| **web** | HTTP server, API route/endpoint, Express/Fastify/Koa, `req`/`res`, CORS config, cookie/session, OAuth, HTML template | `server.ts`, `routes/`, `middleware/`, `.env` with `PORT` |
+| **systems** | daemon, launchd plist, systemd unit, process spawn, `child_process`, file permissions, PID/lock files, CLI entrypoint, signal handlers, `chmod`/`chown` | `launchd/`, `*.plist`, `daemon.ts`, `Makefile`, shell scripts |
+| **cloud** | Dockerfile, docker-compose, CI/CD pipeline, IAM policy, Terraform/CloudFormation, Kubernetes manifest, container registry, secrets manager | `Dockerfile`, `.github/workflows/`, `k8s/`, `terraform/` |
+| **crypto** | encryption/decryption calls, TLS certificate config, key generation, HMAC, digital signature, hash function usage, `crypto` module imports | `crypto.ts`, `certs/`, `*.pem`, `keystore/` |
+
+When multiple domains apply, include all matching domains. When no clear signal is found, default to all four domains to ensure comprehensive coverage.
+
 ## Workflow
 
 ```
-1. Analyze codebase for security vulnerabilities
-2. Run dependency security scans (npm audit)
-3. Check for hardcoded secrets and credentials
-4. Spawn security-engineer for deep security assessment
-5. Compile findings with severity ratings
-6. Provide actionable remediation steps
-7. Escalate CRITICAL/HIGH findings immediately
+1. Infer security domain(s) from project signals and task context
+2. Analyze codebase for security vulnerabilities
+3. Run dependency security scans (npm audit)
+4. Check for hardcoded secrets and credentials
+5. Spawn security-engineer with inferred domain context
+6. Compile findings with severity ratings
+7. Provide actionable remediation steps
+8. Escalate CRITICAL/HIGH findings immediately
 ```
 
 ## Delegation
 
 | Need | Action |
 |------|--------|
-| Deep security assessment | Spawn `security-engineer` |
+| Deep security assessment | Spawn `security-engineer` with domain context |
 | Code remediation | Recommend `/mg-build` with findings |
 | Infrastructure security | Consult `devops-engineer` |
 
 ## Spawn Pattern
 
 ```yaml
-# Security assessment
+# Domain-aware security assessment
 Task:
   subagent_type: security-engineer
   prompt: |
     Perform security audit for workstream {id}.
+
+    **Domain context:** {inferred_domains}
+    Read the domain reference files from domains/ for each applicable domain:
+    - domains/web.md — if web domain applies
+    - domains/systems.md — if systems domain applies
+    - domains/cloud.md — if cloud domain applies
+    - domains/crypto.md — if crypto domain applies
+
+    Load the domain-specific checklists, threat models, and review areas
+    before beginning the audit. Apply them alongside the general review areas.
+
     Focus areas:
     - OWASP Top 10 compliance
     - Authentication/Authorization vulnerabilities
@@ -93,6 +119,7 @@ Task:
     - Secrets management
     - API security
     - Dependency vulnerabilities
+    - Domain-specific threats from loaded reference files
 
     Provide findings with severity (CRITICAL/HIGH/MEDIUM/LOW)
     and specific remediation steps.

--- a/tests/unit/security-domains.test.ts
+++ b/tests/unit/security-domains.test.ts
@@ -1,0 +1,537 @@
+/**
+ * Unit Tests for Security Engineer Domain Reference Files (GH-15)
+ *
+ * Tests the domain-specific reference files for the security-engineer agent.
+ * Validates file existence, structure, required sections, and content quality.
+ * Written BEFORE implementation (TDD - Red phase).
+ *
+ * Misuse-first ordering:
+ * 1. Missing files — domain files don't exist
+ * 2. Empty/malformed files — files exist but have no useful content
+ * 3. Missing required sections — files lack checklists, threat models, or review areas
+ * 4. Insufficient depth — sections exist but are shallow stubs
+ * 5. Happy path — all domains present with full content
+ *
+ * @see GH-15: Agent skill expansions — SME agents per security domain
+ * @target 99% coverage for security domain reference files
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const AGENT_DIR = path.join(
+  __dirname,
+  '../../.claude/agents/security-engineer'
+);
+const DOMAINS_DIR = path.join(AGENT_DIR, 'domains');
+const AGENT_MD = path.join(AGENT_DIR, 'agent.md');
+
+const DOMAIN_NAMES = ['web', 'systems', 'cloud', 'crypto'] as const;
+
+// ============================================================================
+// TEST SECTION 1: File Existence (Misuse: missing files)
+// ============================================================================
+
+describe('GH-15: Security Domain Reference Files — File Existence', () => {
+  it('should have a domains/ directory under security-engineer', () => {
+    expect(fs.existsSync(DOMAINS_DIR)).toBe(true);
+    const stat = fs.statSync(DOMAINS_DIR);
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  for (const domain of DOMAIN_NAMES) {
+    it(`should have ${domain}.md domain reference file`, () => {
+      const filePath = path.join(DOMAINS_DIR, `${domain}.md`);
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+  }
+});
+
+// ============================================================================
+// TEST SECTION 2: Non-empty Content (Misuse: empty/stub files)
+// ============================================================================
+
+describe('GH-15: Security Domain Reference Files — Content Not Empty', () => {
+  for (const domain of DOMAIN_NAMES) {
+    it(`${domain}.md should have substantial content (>500 chars)`, () => {
+      const filePath = path.join(DOMAINS_DIR, `${domain}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content.trim().length).toBeGreaterThan(500);
+    });
+
+    it(`${domain}.md should not be a placeholder stub`, () => {
+      const filePath = path.join(DOMAINS_DIR, `${domain}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8').toLowerCase();
+      expect(content).not.toContain('todo');
+      expect(content).not.toContain('placeholder');
+      expect(content).not.toContain('coming soon');
+      expect(content).not.toContain('tbd');
+    });
+  }
+});
+
+// ============================================================================
+// TEST SECTION 3: Required Sections (Misuse: missing structure)
+// ============================================================================
+
+describe('GH-15: Security Domain Reference Files — Required Sections', () => {
+  const REQUIRED_SECTIONS = [
+    { heading: 'Checklist', description: 'actionable review checklist' },
+    { heading: 'Threat Model', description: 'domain-specific threat model' },
+    { heading: 'Review Areas', description: 'key areas to review' },
+  ];
+
+  for (const domain of DOMAIN_NAMES) {
+    describe(`${domain}.md required sections`, () => {
+      for (const section of REQUIRED_SECTIONS) {
+        it(`should contain a "${section.heading}" section (${section.description})`, () => {
+          const filePath = path.join(DOMAINS_DIR, `${domain}.md`);
+          const content = fs.readFileSync(filePath, 'utf-8');
+          // Match ## Checklist or ## Security Checklist etc.
+          const pattern = new RegExp(
+            `^##\\s+.*${section.heading}`,
+            'im'
+          );
+          expect(content).toMatch(pattern);
+        });
+      }
+    });
+  }
+});
+
+// ============================================================================
+// TEST SECTION 4: Section Depth (Misuse: shallow/empty sections)
+// ============================================================================
+
+describe('GH-15: Security Domain Reference Files — Section Depth', () => {
+  for (const domain of DOMAIN_NAMES) {
+    it(`${domain}.md checklist should have at least 5 items`, () => {
+      const filePath = path.join(DOMAINS_DIR, `${domain}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      // Find checklist section and count list items (- [ ] or - lines)
+      const checklistMatch = content.match(
+        /##\s+.*Checklist\s*\n([\s\S]*?)(?=\n##|\n$|$)/i
+      );
+      expect(checklistMatch).toBeTruthy();
+      if (checklistMatch) {
+        const items = checklistMatch[1].match(/^[\s]*[-*]\s+/gm);
+        expect(items).toBeTruthy();
+        expect(items!.length).toBeGreaterThanOrEqual(5);
+      }
+    });
+
+    it(`${domain}.md threat model should describe at least 3 threats`, () => {
+      const filePath = path.join(DOMAINS_DIR, `${domain}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const threatMatch = content.match(
+        /##\s+.*Threat Model\s*\n([\s\S]*?)(?=\n##|\n$|$)/i
+      );
+      expect(threatMatch).toBeTruthy();
+      if (threatMatch) {
+        // Count threat entries (list items or numbered items or sub-headings)
+        const items = threatMatch[1].match(/^[\s]*[-*\d]+[.)]\s+|^###\s+/gm);
+        expect(items).toBeTruthy();
+        expect(items!.length).toBeGreaterThanOrEqual(3);
+      }
+    });
+
+    it(`${domain}.md review areas should have at least 3 areas`, () => {
+      const filePath = path.join(DOMAINS_DIR, `${domain}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const reviewMatch = content.match(
+        /##\s+.*Review Areas\s*\n([\s\S]*?)(?=\n##|\n$|$)/i
+      );
+      expect(reviewMatch).toBeTruthy();
+      if (reviewMatch) {
+        const items = reviewMatch[1].match(/^[\s]*[-*\d]+[.)]\s+|^###\s+/gm);
+        expect(items).toBeTruthy();
+        expect(items!.length).toBeGreaterThanOrEqual(3);
+      }
+    });
+  }
+});
+
+// ============================================================================
+// TEST SECTION 5: Domain-Specific Content Validation
+// ============================================================================
+
+describe('GH-15: Security Domain Reference Files — Domain-Specific Content', () => {
+  it('web.md should cover OWASP and web-specific concerns', () => {
+    const content = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'web.md'),
+      'utf-8'
+    );
+    expect(content).toMatch(/OWASP/i);
+    expect(content).toMatch(/XSS|cross.site.scripting/i);
+    expect(content).toMatch(/SQL injection|SQLi/i);
+    expect(content).toMatch(/CSRF|cross.site.request.forgery/i);
+    expect(content).toMatch(/authentication|auth[nz]/i);
+  });
+
+  it('systems.md should cover OS hardening and process isolation', () => {
+    const content = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'systems.md'),
+      'utf-8'
+    );
+    expect(content).toMatch(/process isolation|sandboxing/i);
+    expect(content).toMatch(/file permissions|file.system/i);
+    expect(content).toMatch(/daemon|service/i);
+    expect(content).toMatch(/privilege escalation|least privilege/i);
+  });
+
+  it('cloud.md should cover IAM, secrets management, and network policy', () => {
+    const content = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'cloud.md'),
+      'utf-8'
+    );
+    expect(content).toMatch(/IAM|identity.and.access/i);
+    expect(content).toMatch(/secrets? management/i);
+    expect(content).toMatch(/network polic|VPC|firewall/i);
+    expect(content).toMatch(/supply chain|dependency|container/i);
+  });
+
+  it('crypto.md should cover key management and algorithm selection', () => {
+    const content = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'crypto.md'),
+      'utf-8'
+    );
+    expect(content).toMatch(/key management|key rotation/i);
+    expect(content).toMatch(/TLS|transport layer/i);
+    expect(content).toMatch(/algorithm|cipher/i);
+    expect(content).toMatch(/hash|digest/i);
+  });
+});
+
+// ============================================================================
+// TEST SECTION 6: Title and Header Structure
+// ============================================================================
+
+describe('GH-15: Security Domain Reference Files — Title Structure', () => {
+  const EXPECTED_TITLES: Record<string, RegExp> = {
+    web: /^#\s+.*[Ww]eb\s+[Ss]ecurity/m,
+    systems: /^#\s+.*[Ss]ystems?\s+[Ss]ecurity/m,
+    cloud: /^#\s+.*[Cc]loud\s+[Ss]ecurity/m,
+    crypto: /^#\s+.*[Cc]ryptograph/m,
+  };
+
+  for (const domain of DOMAIN_NAMES) {
+    it(`${domain}.md should have a proper H1 title`, () => {
+      const filePath = path.join(DOMAINS_DIR, `${domain}.md`);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toMatch(EXPECTED_TITLES[domain]);
+    });
+  }
+});
+
+// ============================================================================
+// TEST SECTION 7: No Cross-Domain Confusion
+// ============================================================================
+
+describe('GH-15: Security Domain Reference Files — Domain Isolation', () => {
+  it('web.md should not primarily discuss OS/systems topics', () => {
+    const content = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'web.md'),
+      'utf-8'
+    );
+    // Web file should not have launchd, systemd, or kernel references as primary content
+    const lines = content.split('\n');
+    const systemsLines = lines.filter(
+      (l) => /launchd|systemd|kernel module|selinux/i.test(l)
+    );
+    // Allow incidental mentions but not dominant
+    expect(systemsLines.length).toBeLessThan(5);
+  });
+
+  it('systems.md should not primarily discuss web app topics', () => {
+    const content = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'systems.md'),
+      'utf-8'
+    );
+    const lines = content.split('\n');
+    const webLines = lines.filter(
+      (l) => /CSRF|XSS|cookie|session.fixation/i.test(l)
+    );
+    expect(webLines.length).toBeLessThan(5);
+  });
+
+  it('cloud.md should not primarily discuss cryptographic algorithms', () => {
+    const content = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'cloud.md'),
+      'utf-8'
+    );
+    const lines = content.split('\n');
+    const cryptoLines = lines.filter(
+      (l) => /AES-256|RSA-OAEP|elliptic curve|ChaCha20/i.test(l)
+    );
+    expect(cryptoLines.length).toBeLessThan(5);
+  });
+
+  it('crypto.md should not primarily discuss cloud IAM', () => {
+    const content = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'crypto.md'),
+      'utf-8'
+    );
+    const lines = content.split('\n');
+    const cloudLines = lines.filter(
+      (l) => /IAM polic|S3 bucket|EC2 instance|Lambda function/i.test(l)
+    );
+    expect(cloudLines.length).toBeLessThan(5);
+  });
+});
+
+// ============================================================================
+// TEST SECTION 8: SKILL.MD Domain Context Passing (GH-15 Acceptance Criteria)
+// ============================================================================
+
+const SKILL_MD = path.join(
+  __dirname,
+  '../../.claude/skills/mg-security-review/SKILL.md'
+);
+
+describe('GH-15: mg-security-review SKILL.MD — Domain Context Passing', () => {
+  let skillContent: string;
+
+  beforeAll(() => {
+    skillContent = fs.readFileSync(SKILL_MD, 'utf-8');
+  });
+
+  it('should pass domain context in the security-engineer spawn prompt', () => {
+    // The spawn pattern must include domain awareness
+    expect(skillContent).toMatch(/domain/i);
+    const spawnSection = skillContent.match(
+      /##\s+.*Spawn Pattern\s*\n([\s\S]*?)(?=\n##\s|$)/i
+    );
+    expect(spawnSection).toBeTruthy();
+    expect(spawnSection![1]).toMatch(/domain/i);
+  });
+
+  it('should include a domain inference table or mapping', () => {
+    // Must map project signals to domains
+    const domainSection = skillContent.match(
+      /##\s+.*[Dd]omain.*\n([\s\S]*?)(?=\n##\s|$)/
+    );
+    expect(domainSection).toBeTruthy();
+    // The mapping must mention all four domains
+    const section = domainSection![1].toLowerCase();
+    expect(section).toContain('web');
+    expect(section).toContain('systems');
+    expect(section).toContain('cloud');
+    expect(section).toContain('crypto');
+  });
+
+  it('should detect daemon/systems projects without user intervention', () => {
+    // The skill must have heuristics to auto-detect systems domain
+    const lower = skillContent.toLowerCase();
+    // Must mention daemon detection signals
+    expect(lower).toMatch(/daemon|launchd|systemd|plist/);
+    // Must mention auto-detection (not requiring user flag)
+    expect(lower).toMatch(/infer|detect|auto|heuristic|signal/);
+  });
+});
+
+// ============================================================================
+// TEST SECTION 9: AGENT.MD Domain Selection Section (GH-15 Acceptance Criteria)
+// ============================================================================
+
+describe('GH-15: Security Engineer AGENT.MD — Domain Selection', () => {
+  let agentContent: string;
+
+  beforeAll(() => {
+    agentContent = fs.readFileSync(AGENT_MD, 'utf-8');
+  });
+
+  it('should contain a "Domain Selection" section', () => {
+    expect(agentContent).toMatch(/^##\s+Domain Selection/m);
+  });
+
+  it('should instruct the agent to infer the domain from task context', () => {
+    const sectionMatch = agentContent.match(
+      /##\s+Domain Selection\s*\n([\s\S]*?)(?=\n##|\n$|$)/i
+    );
+    expect(sectionMatch).toBeTruthy();
+    const section = sectionMatch![1].toLowerCase();
+    expect(section).toMatch(/infer|detect|determine|identify/);
+    expect(section).toMatch(/context|task|prompt|request/);
+  });
+
+  it('should reference reading domain-specific files', () => {
+    const sectionMatch = agentContent.match(
+      /##\s+Domain Selection\s*\n([\s\S]*?)(?=\n##|\n$|$)/i
+    );
+    expect(sectionMatch).toBeTruthy();
+    const section = sectionMatch![1];
+    expect(section).toMatch(/domains\//);
+    for (const domain of DOMAIN_NAMES) {
+      expect(section).toMatch(new RegExp(`${domain}\\.md`, 'i'));
+    }
+  });
+
+  it('should list all four domains with descriptions', () => {
+    const sectionMatch = agentContent.match(
+      /##\s+Domain Selection\s*\n([\s\S]*?)(?=\n##|\n$|$)/i
+    );
+    expect(sectionMatch).toBeTruthy();
+    const section = sectionMatch![1].toLowerCase();
+    expect(section).toMatch(/web/);
+    expect(section).toMatch(/systems?/);
+    expect(section).toMatch(/cloud/);
+    expect(section).toMatch(/crypto/);
+  });
+
+  it('should not add new agents (agent count must remain at 20)', () => {
+    // Verify the agent.md does not define or reference splitting into multiple agents
+    expect(agentContent).not.toMatch(/security-engineer-web/i);
+    expect(agentContent).not.toMatch(/security-engineer-systems/i);
+    expect(agentContent).not.toMatch(/security-engineer-cloud/i);
+    expect(agentContent).not.toMatch(/security-engineer-crypto/i);
+  });
+});
+
+// ============================================================================
+// TEST SECTION 10: Memory Protocol — domains_reviewed Field (GH-15 AC)
+// ============================================================================
+
+describe('GH-15: Memory Protocol — domains_reviewed Field', () => {
+  it('agent.md memory protocol should include domains_reviewed field', () => {
+    const content = fs.readFileSync(AGENT_MD, 'utf-8');
+    const memorySection = content.match(
+      /##\s+Memory Protocol\s*\n([\s\S]*?)(?=\n##\s|$)/i
+    );
+    expect(memorySection).toBeTruthy();
+    expect(memorySection![1]).toMatch(/domains_reviewed/);
+  });
+
+  it('agent.md domains_reviewed should list domain values', () => {
+    const content = fs.readFileSync(AGENT_MD, 'utf-8');
+    const memorySection = content.match(
+      /##\s+Memory Protocol\s*\n([\s\S]*?)(?=\n##\s|$)/i
+    );
+    expect(memorySection).toBeTruthy();
+    const section = memorySection![1].toLowerCase();
+    // Should reference the domain names as valid values
+    expect(section).toMatch(/web/);
+    expect(section).toMatch(/systems/);
+    expect(section).toMatch(/cloud/);
+    expect(section).toMatch(/crypto/);
+  });
+
+  it('SKILL.md memory protocol should include domains_reviewed field', () => {
+    const content = fs.readFileSync(SKILL_MD, 'utf-8');
+    const memorySection = content.match(
+      /##\s+Memory Protocol\s*\n([\s\S]*?)(?=\n##\s|$)/i
+    );
+    expect(memorySection).toBeTruthy();
+    expect(memorySection![1]).toMatch(/domains_reviewed/);
+  });
+
+  it('SKILL.md domains_reviewed should be an array type', () => {
+    const content = fs.readFileSync(SKILL_MD, 'utf-8');
+    const memorySection = content.match(
+      /##\s+Memory Protocol\s*\n([\s\S]*?)(?=\n##\s|$)/i
+    );
+    expect(memorySection).toBeTruthy();
+    // Should indicate it's a list/array (brackets or "list" or multiple values)
+    const section = memorySection![1];
+    const domainsLine = section
+      .split('\n')
+      .find((l) => /domains_reviewed/.test(l));
+    expect(domainsLine).toBeTruthy();
+    expect(domainsLine!).toMatch(/\[|list|array|web.*systems|web.*cloud/i);
+  });
+});
+
+// ============================================================================
+// TEST SECTION 11: End-to-End — Daemon Codebase OS-Level Detection (GH-15 AC)
+// ============================================================================
+
+describe('GH-15: Domain Detection Heuristics — Daemon Codebase', () => {
+  const skillContent = fs.readFileSync(SKILL_MD, 'utf-8');
+
+  // Extract the domain inference section for testing heuristic completeness
+  const domainSection = skillContent.match(
+    /##\s+.*[Dd]omain.*\n([\s\S]*?)(?=\n##\s|$)/
+  );
+  const inferenceContent = domainSection ? domainSection[1] : '';
+
+  it('should detect systems domain from daemon-related file patterns', () => {
+    const lower = inferenceContent.toLowerCase();
+    expect(lower).toMatch(/daemon/);
+    expect(lower).toMatch(/launchd|plist/);
+    expect(lower).toMatch(/systemd/);
+  });
+
+  it('should detect systems domain from process management signals', () => {
+    const lower = inferenceContent.toLowerCase();
+    expect(lower).toMatch(/child_process|process.*spawn|spawn/);
+    expect(lower).toMatch(/pid|lock.?file/);
+  });
+
+  it('should detect systems domain from file permission signals', () => {
+    const lower = inferenceContent.toLowerCase();
+    expect(lower).toMatch(/chmod|chown|permission/);
+  });
+
+  it('should detect web domain from HTTP/API signals', () => {
+    const lower = inferenceContent.toLowerCase();
+    expect(lower).toMatch(/http|express|fastify/);
+    expect(lower).toMatch(/route|endpoint/);
+  });
+
+  it('should detect cloud domain from container/CI signals', () => {
+    const lower = inferenceContent.toLowerCase();
+    expect(lower).toMatch(/docker/);
+    expect(lower).toMatch(/ci\/cd|pipeline|workflow/);
+  });
+
+  it('should detect crypto domain from encryption signals', () => {
+    const lower = inferenceContent.toLowerCase();
+    expect(lower).toMatch(/encrypt|decrypt/);
+    expect(lower).toMatch(/tls|certificate/);
+    expect(lower).toMatch(/crypto/);
+  });
+
+  it('should default to all domains when signals are ambiguous', () => {
+    const lower = inferenceContent.toLowerCase();
+    expect(lower).toMatch(
+      /default.*all|all.*domain|comprehensive|no.*clear.*signal|ambiguous/i
+    );
+  });
+
+  it('systems.md checklist covers OS-level findings a web-only review would miss', () => {
+    const systemsContent = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'systems.md'),
+      'utf-8'
+    );
+    const checklistMatch = systemsContent.match(
+      /##\s+.*Checklist\s*\n([\s\S]*?)(?=\n##|\n$|$)/i
+    );
+    expect(checklistMatch).toBeTruthy();
+    const checklist = checklistMatch![1].toLowerCase();
+
+    // These are OS-level findings that the original web-only agent missed
+    expect(checklist).toMatch(/non-root|dedicated.*user/);
+    expect(checklist).toMatch(/exec.*style|shell.*interpolation|child_process/i);
+    expect(checklist).toMatch(/chmod|file.*permission|600|640/);
+    expect(checklist).toMatch(/pid.*file|lock.*file/);
+    expect(checklist).toMatch(/signal.*handler/);
+  });
+
+  it('systems.md threat model covers daemon-specific threats', () => {
+    const systemsContent = fs.readFileSync(
+      path.join(DOMAINS_DIR, 'systems.md'),
+      'utf-8'
+    );
+    const threatMatch = systemsContent.match(
+      /##\s+.*Threat Model\s*\n([\s\S]*?)(?=\n##|\n$|$)/i
+    );
+    expect(threatMatch).toBeTruthy();
+    const threats = threatMatch![1].toLowerCase();
+
+    // Daemon-specific threats the web agent missed
+    expect(threats).toMatch(/privilege escalation/);
+    expect(threats).toMatch(/subprocess.*injection|command.*injection/i);
+    expect(threats).toMatch(/daemon.*compromise|service.*compromise/i);
+    expect(threats).toMatch(/supply chain/);
+  });
+});

--- a/tests/unit/security-review.test.ts
+++ b/tests/unit/security-review.test.ts
@@ -136,6 +136,89 @@ describe('Security Review - WS-10', () => {
     });
   });
 
+  describe('Domain-Aware Spawn Pattern (GH-15)', () => {
+    const skillPath = path.join(SKILLS_DIR, 'mg-security-review', 'SKILL.md');
+
+    it('should contain a "Domain Context" or "Domain-Aware" section', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8');
+      expect(content).toMatch(/^##\s+.*[Dd]omain/m);
+    });
+
+    it('should instruct the skill to infer domain from project context', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8');
+      const lower = content.toLowerCase();
+      expect(lower).toMatch(/infer|detect|determine|identify/);
+      expect(lower).toMatch(/domain/);
+    });
+
+    it('should list all four security domains (web, systems, cloud, crypto)', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8').toLowerCase();
+      expect(content).toMatch(/\bweb\b/);
+      expect(content).toMatch(/\bsystems?\b/);
+      expect(content).toMatch(/\bcloud\b/);
+      expect(content).toMatch(/\bcrypto/);
+    });
+
+    it('should include domain-specific file indicators for systems detection', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8').toLowerCase();
+      // Systems domain should detect daemon/launchd/systemd patterns
+      expect(content).toMatch(/daemon|launchd|systemd|service/);
+    });
+
+    it('should include domain-specific file indicators for web detection', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8').toLowerCase();
+      expect(content).toMatch(/http|api|endpoint|route/);
+    });
+
+    it('should include domain-specific file indicators for cloud detection', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8').toLowerCase();
+      expect(content).toMatch(/docker|container|iam|ci\/cd|pipeline/);
+    });
+
+    it('should include domain-specific file indicators for crypto detection', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8').toLowerCase();
+      expect(content).toMatch(/encrypt|tls|certificate|key.?management/);
+    });
+
+    it('spawn pattern should pass domain context to security-engineer', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8');
+      // The spawn pattern should include domain in the prompt
+      const spawnMatch = content.match(
+        /##\s+.*Spawn Pattern\s*\n([\s\S]*?)(?=\n##|\n$|$)/i
+      );
+      expect(spawnMatch).toBeTruthy();
+      if (spawnMatch) {
+        const section = spawnMatch[1];
+        expect(section).toMatch(/domain/i);
+        // Should reference loading domain reference files
+        expect(section).toMatch(/domains?\//i);
+      }
+    });
+
+    it('spawn prompt should instruct agent to read domain reference files', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8');
+      // Within the spawn prompt YAML block, domain file loading must be mentioned
+      expect(content).toMatch(
+        /Read.*domains?\/.*\.md|load.*domain.*reference|domain.*reference.*file/i
+      );
+    });
+
+    it('should provide domain inference rules (not just list domains)', () => {
+      const content = fs.readFileSync(skillPath, 'utf-8');
+      // Must have actual mapping rules, not just domain names
+      const domainSection = content.match(
+        /##\s+.*[Dd]omain.*\n([\s\S]*?)(?=\n##\s|$)/
+      );
+      expect(domainSection).toBeTruthy();
+      if (domainSection) {
+        const section = domainSection[1];
+        // Should contain mapping indicators (file patterns, keywords, or heuristics)
+        const lines = section.split('\n').filter((l) => l.trim().length > 0);
+        expect(lines.length).toBeGreaterThanOrEqual(5);
+      }
+    });
+  });
+
   describe('Boundaries Integrity', () => {
     const skillPath = path.join(SKILLS_DIR, 'mg-security-review', 'SKILL.md');
 


### PR DESCRIPTION
**Ticket:** [GH-15](https://github.com/wonton-web-works/miniature-guacamole/issues/15)

## Description
**Ticket:** [GH-15](https://github.com/wonton-web-works/miniature-guacamole/issues/15) — Agent skill expansions: SME agents per security domain vs. single adaptive security agent

## Workstreams
- Domain reference file authoring
- Security-engineer agent definition update
- mg-security-review skill integration
- Validation and regression testing

## Execution Results
- [FAIL] Domain reference file authoring — Workstream timed out after 1800000ms
- [PASS] Security-engineer agent definition update
- [PASS] mg-security-review skill integration
- [PASS] Validation and regression testing
- [FAIL] quality-gate — Tests failed

---
*Generated by miniature-guacamole daemon*

## Priority
Priority: medium

## Labels
enhancement, mg-daemon

---
*Generated by miniature-guacamole daemon*