### PR TITLE
[GH-107] dry-run-triage

### DIFF
--- a/daemon/src/dry-run.ts
+++ b/daemon/src/dry-run.ts
@@ -2,6 +2,7 @@
 // WS-DAEMON-14: Pipeline Observability & Safety
 
 import type { WorkstreamPlan } from './planner';
+import type { TriageResult } from './triage';
 
 export type { WorkstreamPlan };
 
@@ -11,6 +12,7 @@ export interface DryRunResult {
   plannedWorkstreams: WorkstreamPlan[];
   wouldCreatePR: boolean;
   wouldCreateSubtasks: number;
+  triageResult?: TriageResult;
 }
 
 // Box-drawing constants — all output must fit 80 columns
@@ -51,6 +53,11 @@ export function formatDryRunReport(results: DryRunResult[]): string {
 
     const titleLine = truncate(`${result.ticketId}  ${result.ticketTitle}`, WIDTH - 2);
     lines.push(pad(titleLine));
+
+    if (result.triageResult) {
+      const triageLine = truncate(`  Triage: ${result.triageResult.outcome} — ${result.triageResult.reason}`, WIDTH - 2);
+      lines.push(pad(triageLine));
+    }
 
     if (result.wouldCreatePR) {
       lines.push(pad('  Would create PR'));

--- a/daemon/tests/unit/dry-run.test.ts
+++ b/daemon/tests/unit/dry-run.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { formatDryRunReport } from '../../src/dry-run';
 import type { DryRunResult } from '../../src/dry-run';
+import type { TriageResult } from '../../src/triage';
 
 describe('Dry Run Module', () => {
   // ─── formatDryRunReport ─────────────────────────────────────────────────────
@@ -167,6 +168,100 @@ describe('Dry Run Module', () => {
           plannedWorkstreams: [],
           wouldCreatePR: true,
           wouldCreateSubtasks: 0,
+        }];
+
+        const output = formatDryRunReport(results);
+        const lines = output.split('\n');
+        for (const line of lines) {
+          expect(line.length).toBeLessThanOrEqual(80);
+        }
+      });
+    });
+
+    describe('GIVEN result with triageResult WHEN formatDryRunReport called THEN shows triage info (GH-107)', () => {
+      it('GIVEN triageResult with GO outcome THEN output contains outcome and reason', () => {
+        const triageResult: TriageResult = {
+          outcome: 'GO',
+          reason: 'Ticket is well-defined',
+        };
+        const results: DryRunResult[] = [{
+          ticketId: 'PROJ-123',
+          ticketTitle: 'Add login feature',
+          plannedWorkstreams: [],
+          wouldCreatePR: true,
+          wouldCreateSubtasks: 0,
+          triageResult,
+        }];
+
+        const output = formatDryRunReport(results);
+        expect(output).toContain('GO');
+        expect(output).toContain('Ticket is well-defined');
+      });
+
+      it('GIVEN triageResult with REJECT outcome THEN output contains REJECT and reason', () => {
+        const triageResult: TriageResult = {
+          outcome: 'REJECT',
+          reason: 'Out of scope for this project',
+        };
+        const results: DryRunResult[] = [{
+          ticketId: 'PROJ-456',
+          ticketTitle: 'Invalid request',
+          plannedWorkstreams: [],
+          wouldCreatePR: false,
+          wouldCreateSubtasks: 0,
+          triageResult,
+        }];
+
+        const output = formatDryRunReport(results);
+        expect(output).toContain('REJECT');
+        expect(output).toContain('Out of scope for this project');
+      });
+
+      it('GIVEN triageResult with NEEDS_CLARIFICATION outcome THEN output contains outcome and reason', () => {
+        const triageResult: TriageResult = {
+          outcome: 'NEEDS_CLARIFICATION',
+          reason: 'Missing acceptance criteria',
+          questions: ['What is the expected behavior?'],
+        };
+        const results: DryRunResult[] = [{
+          ticketId: 'PROJ-789',
+          ticketTitle: 'Vague feature',
+          plannedWorkstreams: [],
+          wouldCreatePR: false,
+          wouldCreateSubtasks: 0,
+          triageResult,
+        }];
+
+        const output = formatDryRunReport(results);
+        expect(output).toContain('NEEDS_CLARIFICATION');
+        expect(output).toContain('Missing acceptance criteria');
+      });
+
+      it('GIVEN no triageResult THEN output does not contain Triage line', () => {
+        const results: DryRunResult[] = [{
+          ticketId: 'PROJ-123',
+          ticketTitle: 'Feature',
+          plannedWorkstreams: [],
+          wouldCreatePR: true,
+          wouldCreateSubtasks: 0,
+        }];
+
+        const output = formatDryRunReport(results);
+        expect(output).not.toMatch(/Triage:/);
+      });
+
+      it('GIVEN triageResult with long reason THEN lines are truncated to 80 chars', () => {
+        const triageResult: TriageResult = {
+          outcome: 'NEEDS_CLARIFICATION',
+          reason: 'R'.repeat(100),
+        };
+        const results: DryRunResult[] = [{
+          ticketId: 'PROJ-123',
+          ticketTitle: 'Feature',
+          plannedWorkstreams: [],
+          wouldCreatePR: false,
+          wouldCreateSubtasks: 0,
+          triageResult,
         }];
 
         const output = formatDryRunReport(results);

--- a/daemon/tests/unit/orchestrator.test.ts
+++ b/daemon/tests/unit/orchestrator.test.ts
@@ -594,6 +594,70 @@ describe('processTicket() triage gate (WS-DAEMON-15)', () => {
     });
   });
 
+  describe('AC: dryRun=true triage results in PipelineResult (GH-107)', () => {
+    it('GIVEN dryRun=true and triage GO WHEN processTicket resolves THEN triageResult populated and success=true', async () => {
+      const deps = makeDeps({
+        configOverrides: { dryRun: true },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'GO',
+          reason: 'Ticket is well-defined',
+        } as TriageResult),
+      });
+      const result = await processTicket(TICKET, deps);
+      expect(result.triageResult).toBeDefined();
+      expect(result.triageResult?.outcome).toBe('GO');
+      expect(result.triageResult?.reason).toBe('Ticket is well-defined');
+      expect(result.success).toBe(true);
+    });
+
+    it('GIVEN dryRun=true and triage REJECT WHEN processTicket resolves THEN triageResult populated and success=false', async () => {
+      const deps = makeDeps({
+        configOverrides: { dryRun: true },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'REJECT',
+          reason: 'Out of scope for this project',
+        } as TriageResult),
+      });
+      const result = await processTicket(TICKET, deps);
+      expect(result.triageResult).toBeDefined();
+      expect(result.triageResult?.outcome).toBe('REJECT');
+      expect(result.triageResult?.reason).toBe('Out of scope for this project');
+      expect(result.success).toBe(false);
+    });
+
+    it('GIVEN dryRun=true and triage NEEDS_CLARIFICATION WHEN processTicket resolves THEN triageResult has questions and success=false', async () => {
+      const deps = makeDeps({
+        configOverrides: { dryRun: true },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'NEEDS_CLARIFICATION',
+          reason: 'Missing acceptance criteria',
+          questions: ['What is the expected behavior?', 'Which endpoints are affected?'],
+        } as TriageResult),
+      });
+      const result = await processTicket(TICKET, deps);
+      expect(result.triageResult).toBeDefined();
+      expect(result.triageResult?.outcome).toBe('NEEDS_CLARIFICATION');
+      expect(result.triageResult?.questions).toEqual([
+        'What is the expected behavior?',
+        'Which endpoints are affected?',
+      ]);
+      expect(result.success).toBe(false);
+    });
+
+    it('GIVEN dryRun=true and non-GO triage WHEN processTicket called THEN addComment and addLabel are NOT called', async () => {
+      const deps = makeDeps({
+        configOverrides: { dryRun: true },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'REJECT',
+          reason: 'Not actionable',
+        } as TriageResult),
+      });
+      await processTicket(TICKET, deps);
+      expect(deps.provider.addComment).not.toHaveBeenCalled();
+      expect(deps.provider.addLabel).not.toHaveBeenCalled();
+    });
+  });
+
   describe('AC: Tracker updated on triage failure', () => {
     it('GIVEN triage returns NEEDS_CLARIFICATION WHEN processTicket called THEN markFailed is called', async () => {
       const deps = makeDeps({


### PR DESCRIPTION
**Ticket:** [GH-107](https://github.com/wonton-web-works/miniature-guacamole/issues/107)

## Description
**Ticket:** [GH-107](https://github.com/wonton-web-works/miniature-guacamole/issues/107) — dry-run-triage

## Workstreams
- DRY-RUN-TRIAGE-TESTS
- DRY-RUN-REPORT-TRIAGE

## Execution Results
- [PASS] DRY-RUN-TRIAGE-TESTS
- [PASS] DRY-RUN-REPORT-TRIAGE
- [FAIL] quality-gate — Tests failed

---
*Generated by miniature-guacamole daemon*

## Priority
Priority: medium

## Labels
mg-daemon

---
*Generated by miniature-guacamole daemon*