### PR TITLE
[GH-105] non-go-feedback

### DIFF
--- a/daemon/src/feedback.ts
+++ b/daemon/src/feedback.ts
@@ -1,0 +1,35 @@
+// Non-GO triage feedback formatting
+// GH-105: Comment writeback for NEEDS_CLARIFICATION and REJECT outcomes
+
+import type { TriageResult, TriageOutcome } from './triage';
+
+/**
+ * Format a triage result into a provider-agnostic markdown comment body.
+ *
+ * Structure:
+ *   **Triage: {OUTCOME}**
+ *
+ *   {reason}
+ *
+ *   **Questions:**
+ *   - question 1
+ *   - question 2
+ *
+ * The Questions section is only included when questions are present and non-empty.
+ */
+export function formatTriageFeedback(result: TriageResult): string {
+  let comment = `**Triage: ${result.outcome}**\n\n${result.reason}`;
+
+  if (result.questions && result.questions.length > 0) {
+    comment += '\n\n**Questions:**\n' + result.questions.map(q => `- ${q}`).join('\n');
+  }
+
+  return comment;
+}
+
+/**
+ * Map a non-GO triage outcome to its corresponding label.
+ */
+export function triageLabelFor(outcome: TriageOutcome): string {
+  return outcome === 'REJECT' ? 'mg-daemon:rejected' : 'mg-daemon:needs-info';
+}

--- a/daemon/src/orchestrator.ts
+++ b/daemon/src/orchestrator.ts
@@ -17,6 +17,7 @@ import { executeWorkstream as defaultExecuteWorkstream } from './executor';
 import { triageTicket as defaultTriageTicket } from './triage';
 import { createWorktree as defaultCreateWorktree, removeWorktree as defaultRemoveWorktree } from './worktree';
 import { createPR as defaultCreatePR } from './github';
+import { formatTriageFeedback, triageLabelFor } from './feedback';
 import { ConcurrencyLimiter } from './concurrency';
 import { appendTriageLog } from './triage-log';
 import { spawnSync } from 'child_process';
@@ -188,23 +189,14 @@ export async function processTicket(
   }
 
   if (triageResult.outcome !== 'GO') {
-    // Post comment to ticket explaining the triage decision
+    // Post comment to ticket explaining the triage decision (GH-105)
+    // Each call is independent best-effort — one failing must not block the other
     if (!dryRun) {
-      try {
-        const label = triageResult.outcome === 'REJECT'
-          ? 'mg-daemon:rejected'
-          : 'mg-daemon:needs-info';
+      const comment = formatTriageFeedback(triageResult);
+      const label = triageLabelFor(triageResult.outcome);
 
-        let comment = `**Triage: ${triageResult.outcome}**\n\n${triageResult.reason}`;
-        if (triageResult.questions && triageResult.questions.length > 0) {
-          comment += '\n\n**Questions:**\n' + triageResult.questions.map(q => `- ${q}`).join('\n');
-        }
-
-        await deps.provider.addComment(ticket.id, comment);
-        await deps.provider.addLabel(ticket.id, label);
-      } catch {
-        // Best-effort — don't fail the pipeline on comment/label errors
-      }
+      try { await deps.provider.addComment(ticket.id, comment); } catch { /* best-effort */ }
+      try { await deps.provider.addLabel(ticket.id, label); } catch { /* best-effort */ }
     }
 
     deps.tracker.markFailed(ticket.id, `Triage: ${triageResult.outcome} — ${triageResult.reason}`);

--- a/daemon/tests/unit/feedback.test.ts
+++ b/daemon/tests/unit/feedback.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import { formatTriageFeedback, triageLabelFor } from '../../src/feedback';
+import type { TriageResult } from '../../src/triage';
+
+// ---------------------------------------------------------------------------
+// GH-105: Non-GO feedback comment formatting
+// ---------------------------------------------------------------------------
+
+describe('formatTriageFeedback() (GH-105)', () => {
+  // -------------------------------------------------------------------
+  // Misuse-first: edge cases and invalid inputs
+  // -------------------------------------------------------------------
+
+  describe('MISUSE: edge cases', () => {
+    it('GIVEN empty reason WHEN formatting THEN comment still contains outcome header', () => {
+      const result: TriageResult = { outcome: 'REJECT', reason: '' };
+      const body = formatTriageFeedback(result);
+      expect(body).toContain('**Triage: REJECT**');
+    });
+
+    it('GIVEN questions is empty array WHEN formatting THEN no Questions section appears', () => {
+      const result: TriageResult = {
+        outcome: 'NEEDS_CLARIFICATION',
+        reason: 'Missing details',
+        questions: [],
+      };
+      const body = formatTriageFeedback(result);
+      expect(body).not.toContain('**Questions:**');
+    });
+
+    it('GIVEN questions is undefined WHEN formatting THEN no Questions section appears', () => {
+      const result: TriageResult = {
+        outcome: 'NEEDS_CLARIFICATION',
+        reason: 'Missing details',
+      };
+      const body = formatTriageFeedback(result);
+      expect(body).not.toContain('**Questions:**');
+    });
+
+    it('GIVEN reason contains markdown special chars WHEN formatting THEN they are preserved (not escaped)', () => {
+      const result: TriageResult = {
+        outcome: 'REJECT',
+        reason: 'Ticket references `auth` module & payment <gateway>',
+      };
+      const body = formatTriageFeedback(result);
+      expect(body).toContain('Ticket references `auth` module & payment <gateway>');
+    });
+
+    it('GIVEN question contains markdown WHEN formatting THEN it is preserved as-is', () => {
+      const result: TriageResult = {
+        outcome: 'NEEDS_CLARIFICATION',
+        reason: 'Unclear',
+        questions: ['What does `foo()` return?'],
+      };
+      const body = formatTriageFeedback(result);
+      expect(body).toContain('- What does `foo()` return?');
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // AC: NEEDS_CLARIFICATION comment body
+  // -------------------------------------------------------------------
+
+  describe('AC: NEEDS_CLARIFICATION comment contains outcome, reason, and questions', () => {
+    const NEEDS_CLARIFICATION_WITH_QUESTIONS: TriageResult = {
+      outcome: 'NEEDS_CLARIFICATION',
+      reason: 'Missing acceptance criteria',
+      questions: [
+        'What should the endpoint return on success?',
+        'Should authentication be required?',
+      ],
+    };
+
+    it('GIVEN NEEDS_CLARIFICATION with questions WHEN formatting THEN body contains triage outcome', () => {
+      const body = formatTriageFeedback(NEEDS_CLARIFICATION_WITH_QUESTIONS);
+      expect(body).toContain('**Triage: NEEDS_CLARIFICATION**');
+    });
+
+    it('GIVEN NEEDS_CLARIFICATION with questions WHEN formatting THEN body contains reason string', () => {
+      const body = formatTriageFeedback(NEEDS_CLARIFICATION_WITH_QUESTIONS);
+      expect(body).toContain('Missing acceptance criteria');
+    });
+
+    it('GIVEN NEEDS_CLARIFICATION with questions WHEN formatting THEN body contains bullet-list of questions', () => {
+      const body = formatTriageFeedback(NEEDS_CLARIFICATION_WITH_QUESTIONS);
+      expect(body).toContain('- What should the endpoint return on success?');
+      expect(body).toContain('- Should authentication be required?');
+    });
+
+    it('GIVEN NEEDS_CLARIFICATION with questions WHEN formatting THEN questions appear under Questions header', () => {
+      const body = formatTriageFeedback(NEEDS_CLARIFICATION_WITH_QUESTIONS);
+      expect(body).toContain('**Questions:**');
+      const questionsIndex = body.indexOf('**Questions:**');
+      const firstQuestion = body.indexOf('- What should the endpoint return on success?');
+      expect(firstQuestion).toBeGreaterThan(questionsIndex);
+    });
+
+    it('GIVEN NEEDS_CLARIFICATION without questions WHEN formatting THEN body has outcome and reason only', () => {
+      const result: TriageResult = {
+        outcome: 'NEEDS_CLARIFICATION',
+        reason: 'Vague description',
+      };
+      const body = formatTriageFeedback(result);
+      expect(body).toContain('**Triage: NEEDS_CLARIFICATION**');
+      expect(body).toContain('Vague description');
+      expect(body).not.toContain('**Questions:**');
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // AC: REJECT comment body
+  // -------------------------------------------------------------------
+
+  describe('AC: REJECT comment contains outcome and rejection reason', () => {
+    const REJECT_RESULT: TriageResult = {
+      outcome: 'REJECT',
+      reason: 'Out of scope — ticket describes infrastructure work, not code changes',
+    };
+
+    it('GIVEN REJECT WHEN formatting THEN body contains triage outcome', () => {
+      const body = formatTriageFeedback(REJECT_RESULT);
+      expect(body).toContain('**Triage: REJECT**');
+    });
+
+    it('GIVEN REJECT WHEN formatting THEN body contains rejection reason', () => {
+      const body = formatTriageFeedback(REJECT_RESULT);
+      expect(body).toContain('Out of scope — ticket describes infrastructure work, not code changes');
+    });
+
+    it('GIVEN REJECT WHEN formatting THEN body does NOT contain Questions section', () => {
+      const body = formatTriageFeedback(REJECT_RESULT);
+      expect(body).not.toContain('**Questions:**');
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // AC: comment body is provider-agnostic markdown
+  // -------------------------------------------------------------------
+
+  describe('AC: comment body is provider-agnostic markdown', () => {
+    it('GIVEN any result WHEN formatting THEN outcome header uses bold markdown', () => {
+      const result: TriageResult = { outcome: 'REJECT', reason: 'No' };
+      const body = formatTriageFeedback(result);
+      expect(body).toMatch(/\*\*Triage: \w+\*\*/);
+    });
+
+    it('GIVEN questions WHEN formatting THEN questions header uses bold markdown', () => {
+      const result: TriageResult = {
+        outcome: 'NEEDS_CLARIFICATION',
+        reason: 'Unclear',
+        questions: ['What?'],
+      };
+      const body = formatTriageFeedback(result);
+      expect(body).toMatch(/\*\*Questions:\*\*/);
+    });
+
+    it('GIVEN questions WHEN formatting THEN each question is a markdown bullet', () => {
+      const result: TriageResult = {
+        outcome: 'NEEDS_CLARIFICATION',
+        reason: 'Unclear',
+        questions: ['Q1', 'Q2', 'Q3'],
+      };
+      const body = formatTriageFeedback(result);
+      expect(body).toContain('- Q1\n- Q2\n- Q3');
+    });
+
+    it('GIVEN any result WHEN formatting THEN no HTML tags are used', () => {
+      const result: TriageResult = {
+        outcome: 'NEEDS_CLARIFICATION',
+        reason: 'Missing info',
+        questions: ['What API?'],
+      };
+      const body = formatTriageFeedback(result);
+      // Should not use <p>, <ul>, <li>, <b>, etc.
+      expect(body).not.toMatch(/<(?:p|ul|ol|li|b|strong|em|div|span)\b/i);
+    });
+
+    it('GIVEN any result WHEN formatting THEN no Jira/Linear/GitHub-specific markup is used', () => {
+      const result: TriageResult = {
+        outcome: 'NEEDS_CLARIFICATION',
+        reason: 'Unclear',
+        questions: ['What?'],
+      };
+      const body = formatTriageFeedback(result);
+      // No Jira wiki markup
+      expect(body).not.toMatch(/\{code\}/);
+      expect(body).not.toMatch(/h[1-6]\./);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Snapshot: full formatted comment
+  // -------------------------------------------------------------------
+
+  describe('full comment snapshot', () => {
+    it('GIVEN NEEDS_CLARIFICATION with 2 questions WHEN formatting THEN matches expected markdown', () => {
+      const result: TriageResult = {
+        outcome: 'NEEDS_CLARIFICATION',
+        reason: 'Missing acceptance criteria',
+        questions: ['What should the response format be?', 'Is auth required?'],
+      };
+      const body = formatTriageFeedback(result);
+      expect(body).toBe(
+        '**Triage: NEEDS_CLARIFICATION**\n\n' +
+        'Missing acceptance criteria\n\n' +
+        '**Questions:**\n' +
+        '- What should the response format be?\n' +
+        '- Is auth required?'
+      );
+    });
+
+    it('GIVEN REJECT WHEN formatting THEN matches expected markdown', () => {
+      const result: TriageResult = { outcome: 'REJECT', reason: 'Out of scope' };
+      const body = formatTriageFeedback(result);
+      expect(body).toBe('**Triage: REJECT**\n\nOut of scope');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// triageLabelFor()
+// ---------------------------------------------------------------------------
+
+describe('triageLabelFor() (GH-105)', () => {
+  it('GIVEN NEEDS_CLARIFICATION WHEN getting label THEN returns mg-daemon:needs-info', () => {
+    expect(triageLabelFor('NEEDS_CLARIFICATION')).toBe('mg-daemon:needs-info');
+  });
+
+  it('GIVEN REJECT WHEN getting label THEN returns mg-daemon:rejected', () => {
+    expect(triageLabelFor('REJECT')).toBe('mg-daemon:rejected');
+  });
+});

--- a/daemon/tests/unit/orchestrator.test.ts
+++ b/daemon/tests/unit/orchestrator.test.ts
@@ -510,19 +510,37 @@ describe('processTicket() triage gate (WS-DAEMON-15)', () => {
     });
   });
 
-  describe('AC: Triage failure posts comment and label', () => {
-    it('GIVEN triage returns NEEDS_CLARIFICATION WHEN processTicket called THEN addComment is called', async () => {
+  describe('AC: Triage failure posts comment and label (GH-105)', () => {
+    it('GIVEN NEEDS_CLARIFICATION with questions WHEN processTicket called THEN addComment body contains outcome, reason, and bullet-list questions', async () => {
       const deps = makeDeps({
         triageTicket: vi.fn().mockResolvedValue({
           outcome: 'NEEDS_CLARIFICATION',
-          reason: 'Unclear',
-          questions: ['What endpoint?'],
+          reason: 'Missing acceptance criteria',
+          questions: ['What endpoint?', 'Auth required?'],
         } as TriageResult),
       });
       await processTicket(TICKET, deps);
       expect(deps.provider.addComment).toHaveBeenCalledWith(
         TICKET.id,
-        expect.stringContaining('NEEDS_CLARIFICATION')
+        '**Triage: NEEDS_CLARIFICATION**\n\n' +
+        'Missing acceptance criteria\n\n' +
+        '**Questions:**\n' +
+        '- What endpoint?\n' +
+        '- Auth required?'
+      );
+    });
+
+    it('GIVEN NEEDS_CLARIFICATION without questions WHEN processTicket called THEN addComment body has outcome and reason only', async () => {
+      const deps = makeDeps({
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'NEEDS_CLARIFICATION',
+          reason: 'Unclear',
+        } as TriageResult),
+      });
+      await processTicket(TICKET, deps);
+      expect(deps.provider.addComment).toHaveBeenCalledWith(
+        TICKET.id,
+        '**Triage: NEEDS_CLARIFICATION**\n\nUnclear'
       );
     });
 
@@ -535,6 +553,20 @@ describe('processTicket() triage gate (WS-DAEMON-15)', () => {
       });
       await processTicket(TICKET, deps);
       expect(deps.provider.addLabel).toHaveBeenCalledWith(TICKET.id, 'mg-daemon:needs-info');
+    });
+
+    it('GIVEN REJECT WHEN processTicket called THEN addComment body contains outcome and rejection reason', async () => {
+      const deps = makeDeps({
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'REJECT',
+          reason: 'Out of scope',
+        } as TriageResult),
+      });
+      await processTicket(TICKET, deps);
+      expect(deps.provider.addComment).toHaveBeenCalledWith(
+        TICKET.id,
+        '**Triage: REJECT**\n\nOut of scope'
+      );
     });
 
     it('GIVEN triage returns REJECT WHEN processTicket called THEN adds rejected label', async () => {
@@ -562,6 +594,114 @@ describe('processTicket() triage gate (WS-DAEMON-15)', () => {
       const result = await processTicket(TICKET, deps);
       expect(result.success).toBe(false);
       expect(result.triageResult?.outcome).toBe('NEEDS_CLARIFICATION');
+    });
+
+    it('GIVEN addLabel throws but addComment succeeds WHEN processTicket called THEN pipeline still returns (best-effort)', async () => {
+      const deps = makeDeps({
+        providerOverrides: {
+          addLabel: vi.fn().mockRejectedValue(new Error('label API error')),
+        },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'REJECT',
+          reason: 'Nope',
+        } as TriageResult),
+      });
+      const result = await processTicket(TICKET, deps);
+      expect(result.success).toBe(false);
+      // Comment was still attempted even though label will fail
+      expect(deps.provider.addComment).toHaveBeenCalled();
+    });
+
+    it('GIVEN addComment throws WHEN processTicket called THEN addLabel is still attempted', async () => {
+      const addComment = vi.fn().mockRejectedValue(new Error('comment API error'));
+      const addLabel = vi.fn().mockResolvedValue(undefined);
+      const deps = makeDeps({
+        providerOverrides: { addComment, addLabel },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'NEEDS_CLARIFICATION',
+          reason: 'Vague',
+        } as TriageResult),
+      });
+      await processTicket(TICKET, deps);
+      expect(addComment).toHaveBeenCalled();
+      expect(addLabel).toHaveBeenCalledWith(TICKET.id, 'mg-daemon:needs-info');
+    });
+
+    it('GIVEN addComment throws WHEN processTicket called THEN markFailed is still called with triage reason', async () => {
+      const deps = makeDeps({
+        providerOverrides: {
+          addComment: vi.fn().mockRejectedValue(new Error('API error')),
+        },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'NEEDS_CLARIFICATION',
+          reason: 'Missing details',
+        } as TriageResult),
+      });
+      await processTicket(TICKET, deps);
+      expect(deps.tracker.markFailed).toHaveBeenCalledWith(
+        TICKET.id,
+        expect.stringContaining('NEEDS_CLARIFICATION')
+      );
+      expect(deps.tracker.markFailed).toHaveBeenCalledWith(
+        TICKET.id,
+        expect.stringContaining('Missing details')
+      );
+    });
+
+    it('GIVEN addLabel throws WHEN processTicket called THEN markFailed is still called with triage reason', async () => {
+      const deps = makeDeps({
+        providerOverrides: {
+          addLabel: vi.fn().mockRejectedValue(new Error('label error')),
+        },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'REJECT',
+          reason: 'Out of scope',
+        } as TriageResult),
+      });
+      await processTicket(TICKET, deps);
+      expect(deps.tracker.markFailed).toHaveBeenCalledWith(
+        TICKET.id,
+        expect.stringContaining('REJECT')
+      );
+      expect(deps.tracker.markFailed).toHaveBeenCalledWith(
+        TICKET.id,
+        expect.stringContaining('Out of scope')
+      );
+    });
+
+    it('GIVEN both addComment and addLabel throw WHEN processTicket called THEN markFailed is still called with triage reason', async () => {
+      const deps = makeDeps({
+        providerOverrides: {
+          addComment: vi.fn().mockRejectedValue(new Error('comment error')),
+          addLabel: vi.fn().mockRejectedValue(new Error('label error')),
+        },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'REJECT',
+          reason: 'Not actionable',
+        } as TriageResult),
+      });
+      const result = await processTicket(TICKET, deps);
+      expect(result.success).toBe(false);
+      expect(result.triageResult?.outcome).toBe('REJECT');
+      expect(deps.tracker.markFailed).toHaveBeenCalledWith(
+        TICKET.id,
+        expect.stringContaining('Not actionable')
+      );
+    });
+
+    it('GIVEN writeback fails WHEN processTicket called THEN processTicket does NOT throw', async () => {
+      const deps = makeDeps({
+        providerOverrides: {
+          addComment: vi.fn().mockRejectedValue(new Error('boom')),
+          addLabel: vi.fn().mockRejectedValue(new Error('boom')),
+        },
+        triageTicket: vi.fn().mockResolvedValue({
+          outcome: 'NEEDS_CLARIFICATION',
+          reason: 'Unclear',
+        } as TriageResult),
+      });
+      // Should resolve, not reject
+      await expect(processTicket(TICKET, deps)).resolves.toBeDefined();
     });
   });
 


### PR DESCRIPTION
**Ticket:** [GH-105](https://github.com/wonton-web-works/miniature-guacamole/issues/105)

## Description
**Ticket:** [GH-105](https://github.com/wonton-web-works/miniature-guacamole/issues/105) — non-go-feedback

## Workstreams
- comment-writeback
- label-writeback
- best-effort-resilience

## Execution Results
- [PASS] comment-writeback
- [PASS] label-writeback
- [PASS] best-effort-resilience
- [FAIL] quality-gate — Tests failed

---
*Generated by miniature-guacamole daemon*

## Priority
Priority: medium

## Labels
mg-daemon

---
*Generated by miniature-guacamole daemon*